### PR TITLE
fix for csv exports

### DIFF
--- a/lib/generators/templates/app/controllers/base.rb
+++ b/lib/generators/templates/app/controllers/base.rb
@@ -58,7 +58,7 @@ class <%= namespace_for_class %><%= model_camelize.pluralize %>Controller < Beau
             csv << <%= model_camelize %>.attribute_names.map{ |a| o[a] }
           }
         end 
-        render :text => csvstr
+        render :plain => csvstr
       }
       format.xml{ 
         render :xml => @<%= model %>_scope.to_a


### PR DESCRIPTION
switched to render :plain since render :text was deprecated and now breaks in Rails 5.1